### PR TITLE
Added a Controller to Compute Engine Integration Test

### DIFF
--- a/test/integration/ComputeEngineIntegrationTest.java
+++ b/test/integration/ComputeEngineIntegrationTest.java
@@ -8,16 +8,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import engine.computeapi.ComputeEngine;
 import engine.controller.Controller;
-import engine.dataapi.DataStore;
-import engine.dataapi.DataStream;
-import engine.userapi.User;
 import engine.userapi.UserDataStream;
 //import engine.controller.*;//real component
 //import engine.computeapi.*;//another real component
-import infrastructure.TestUserDataInput;//test data input
-import infrastructure.TestUserDataStream;//test output
 import infrastructure.IntegrationDataStore;//fake db
 
 

--- a/test/integration/ControllerToComputeIntegration.java
+++ b/test/integration/ControllerToComputeIntegration.java
@@ -1,0 +1,38 @@
+package integration;
+
+import org.junit.jupiter.api.Test;
+
+import engine.computeapi.ComputeEngine;
+import engine.computeapi.ComputeEngineDataStream;
+import engine.controller.Controller;
+import engine.dataapi.DataStore;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ControllerToComputeIntegration {
+	
+	/**
+	 * Integration test between the compute engine and controller.
+	 */
+	@Test
+	public void test() {
+		DataStore ds = new DataStore();
+		ComputeEngine testEngine = new ComputeEngine();
+		ComputeEngineDataStream data = new ComputeEngineDataStream(3);
+		Controller testController = new Controller(ds);
+		
+		try {
+			testController.sendComputeRequest(data);
+			try {
+				testEngine.receiveComputeRequest(data);
+			} catch(IllegalArgumentException e) {
+				e.printStackTrace();
+				fail();
+			}
+		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+	
+}


### PR DESCRIPTION
I created a DataStore, ComputeEngine, ComputeEngineDataStream, and Controller and tested the sendComputeRequest method from the controller. I surrounded the method call in a try/catch block. If that method succeeds, the receiveComputeRequest method will be called in another try catch block. So far, the test is passing when running it through JUnit.